### PR TITLE
iso: support iso in iso

### DIFF
--- a/pathlab/__init__.py
+++ b/pathlab/__init__.py
@@ -2,6 +2,7 @@ from pathlab.core.accessor import Accessor
 from pathlab.core.creator import Creator
 from pathlab.core.path import Path
 from pathlab.core.stat import Stat
+from pathlab.core.fileinfile import FileInFile
 from pathlab.iso import IsoAccessor
 from pathlab.rt import RtAccessor
 from pathlab.tar import TarAccessor

--- a/pathlab/core/fileinfile.py
+++ b/pathlab/core/fileinfile.py
@@ -1,0 +1,53 @@
+import os
+import io
+import mmap
+
+class FileInFile(io.IOBase):
+    def __init__(self, parent, offset, length):
+        if isinstance(parent, FileInFile):
+            # in this case, data is already mapped, so we just adapt the offsets
+            self.data = parent.data
+            self.offset = parent.offset + offset
+            self.length = length
+            assert parent.length >= offset + length
+        else:
+            self.data = mmap.mmap(parent.fileno(), 0, prot=mmap.PROT_READ)
+            self.offset = offset
+            self.length = length
+        self.pos = 0
+
+    def seek(self, offset, whence=os.SEEK_SET):
+        if whence == os.SEEK_SET:
+            self.pos = offset
+        elif whence == os.SEEK_END:
+            self.pos = self.length - offset
+        elif whence == os.SEEK_CUR:
+            self.pos += offset
+
+    def peek(self, size):
+        return self.read(size, peek=True)
+
+    def read(self, size=None, peek=False):
+        if self.pos >= self.length:
+            return b''
+
+        if size is None or self.pos + size > self.length:
+            size = self.length - self.pos
+
+        o = self.pos + self.offset
+        data = self.data[o:o + size]
+        if not peek:
+            self.pos += size
+        return data
+
+    def tell(self):
+        return self.pos
+
+    def writable(self) -> bool:
+        return False
+
+    def readable(self) -> bool:
+        return True
+
+    def as_buffer(self):
+        return memoryview(self.data)[self.offset: self.offset + self.length]

--- a/pathlab/iso.py
+++ b/pathlab/iso.py
@@ -1,5 +1,4 @@
 import datetime
-import io
 import functools
 import struct
 
@@ -17,7 +16,6 @@ TF_FIELDS = ('create_time', 'modify_time', 'access_time', 'status_time',
 
 class IsoPath(pathlab.Path):
     __slots__ = ()
-
 
 class IsoAccessor(pathlab.Accessor):
     """
@@ -332,7 +330,7 @@ class IsoAccessor(pathlab.Accessor):
         if mode == "r":
             record = self._load_record(path)
             self.fileobj.seek(SECTOR * record['sector'])
-            return io.BytesIO(self.fileobj.read(record['size']))
+            return pathlab.FileInFile(self.fileobj, self.fileobj.tell(), record['size'])
         raise NotImplementedError
 
     def close(self):


### PR DESCRIPTION
I have some files that contain iso files inside iso files that I would like to explore programatically.

The previous designed failed because BytesIO do not support peek()

I choose to implement a FileInFile reader object, which supports peek, but also, which only memory maps the objects, which allows to avoid loading the whole file in memory.
